### PR TITLE
Serverside rendering fails in isomorphic app

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var React = require('react');
 var cloneWithProps = require('react/lib/cloneWithProps');
 var PureRenderMixin = require('react/addons').addons.PureRenderMixin;
-var Ladda = require('ladda/dist/ladda.min');
 
 var LaddaButton = React.createClass({
   displayName: 'LaddaButton',
@@ -23,7 +22,7 @@ var LaddaButton = React.createClass({
   },
 
   componentDidMount: function() {
-    this.laddaButton = Ladda.create(this.getDOMNode());
+    this.laddaButton = require('ladda/dist/ladda.min').create(this.getDOMNode());
   },
 
   componentWillUnmount: function() {


### PR DESCRIPTION
Spin.js is throwing an exception when using ladda in a isomorphic application due to its dependency on the document object and the dom not yet being available. Moving the require statement for the raw Ladda lib to componentDidMount defers evaluation of spin.js until there is a dom.