### PR TITLE
Replace deprecated getDOMNode()

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var LaddaButton = React.createClass({
   },
 
   componentDidMount: function() {
-    this.laddaButton = require('ladda/dist/ladda.min').create(this.getDOMNode());
+    this.laddaButton = require('ladda/dist/ladda.min').create(React.findDOMNode(this));
   },
 
   componentWillUnmount: function() {


### PR DESCRIPTION
Method getDOMNode is deprecated since React v0.13,
https://facebook.github.io/react/docs/component-api.html#getdomnode