### PR TITLE
Fix overwriting of disabled property on DOM button

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,11 @@ var LaddaButton = React.createClass({
       return;
     }
 
+    // skip if the button was initially disabled
+    if (!this.props.active && this.props.children.props.disabled) {
+      return;
+    }
+
     if (this.props.active) {
       if (!this.active) {
         this.active = true;


### PR DESCRIPTION
When the button is initially or simply manually disabled (possible
when Ladda is wrapped by another component), when the Ladda button
is not active, it skips the `laddaButton.remove()` call to persist
the disabled state.

Resolves #12