### PR TITLE
Fix componentDidUpdate logic when props change simultaneously

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,14 +43,18 @@ var LaddaButton = React.createClass({
     }
   },
 
-  componentDidUpdate: function() {
+  componentDidUpdate: function(prevProps) {
     if (!this.laddaButton) {
       return;
     }
 
-    // Skip if the button was initially disabled.
-    if (!this.props.loading && this.props.disabled) {
+    // Skip if all props are the same
+    if(prevProps.loading === this.props.loading && prevProps.disabled === this.props.disabled) {
       return;
+    }
+
+    if (!prevProps.disabled && this.props.disabled) {
+      this.laddaButton.disable();
     }
 
     if (this.props.loading && !this.laddaButton.isLoading()) {


### PR DESCRIPTION
Previously if `disabled` was `true` and `loading` was false no change was made, but this did not account for prop changes where

* loading: true -> false
* disabled: false -> true

in the same update. This fixes that to only return if no prop changes were made.