### PR TITLE
Bump dependency versions to use with react v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "React wrapper for Ladda buttons.",
   "main": "index.js",
   "peerDependencies": {
-    "react": ">=0.14.0",
-    "react-dom": ">=0.14.0"
+    "react": ">=0.15.0",
+    "react-dom": ">=0.15.0"
   },
   "scripts": {
     "test": "jest"
@@ -28,13 +28,13 @@
   "homepage": "https://github.com/jsdir/react-ladda",
   "devDependencies": {
     "jest-cli": "^0.2.1",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0",
-    "react-addons-test-utils": "^0.14.0"
+    "react": "^0.15.0",
+    "react-dom": "^0.15.0",
+    "react-addons-test-utils": "^15.0.1"
   },
   "dependencies": {
     "ladda": "^0.9.8",
-    "react-addons-pure-render-mixin": "^0.14.0"
+    "react-addons-pure-render-mixin": "^15.0.1"
   },
   "jest": {
     "unmockedModulePathPatterns": [


### PR DESCRIPTION
After upgrading to React v15 packages requiring React v~14 cause issues, see https://gist.github.com/jimfb/4faa6cbfb1ef476bd105. 

Bumped versions in dependencies to avoid errors.