### PR TITLE
Fix updateLaddaInstance: call disable() if props.disabled

### DIFF
--- a/src/LaddaButton.jsx
+++ b/src/LaddaButton.jsx
@@ -74,6 +74,8 @@ class LaddaButton extends Component {
     if (props.loading !== this.props.loading) {
       if (props.loading) {
         this.laddaInstance.start()
+      } else if (props.disabled) {
+        this.laddaInstance.disable()
       } else {
         this.laddaInstance.stop()
       }

--- a/src/LaddaButton.jsx
+++ b/src/LaddaButton.jsx
@@ -75,6 +75,9 @@ class LaddaButton extends Component {
       if (props.loading) {
         this.laddaInstance.start()
       } else if (props.disabled) {
+        // .stop removes the attribute "disabled"
+        // .disable calls .stop then adds the attribute "disabled"
+        // see https://github.com/hakimel/Ladda/blob/master/js/ladda.js
         this.laddaInstance.disable()
       } else {
         this.laddaInstance.stop()

--- a/test/LaddaButton-test.jsx
+++ b/test/LaddaButton-test.jsx
@@ -88,16 +88,19 @@ describe('LaddaButton', () => {
   it('should disable the button if the `props.disabled` is set', () => {
     const wrapper = mount(<LaddaButton disabled />)
     expect(wrapper.find('button').prop('disabled')).to.eq(true)
-    expect(wrapper.find('button')).to.have.attr('disabled')
-    wrapper.setProps({ loading: true })
-    wrapper.setProps({ loading: false })
-    expect(wrapper.find('button').prop('disabled')).to.eq(true)
-    expect(wrapper.find('button')).to.have.attr('disabled')
   })
 
   it('should disable the button if `props.loading` is truthy', () => {
     const wrapper = mount(<LaddaButton loading />)
     expect(wrapper.find('button').prop('disabled')).to.eq(true)
+  })
+
+  it('should keep the attribute `disabled` after loading', () => {
+    const wrapper = mount(<LaddaButton disabled />)
+    expect(wrapper.find('button')).to.have.attr('disabled')
+    wrapper.setProps({ loading: true })
+    wrapper.setProps({ loading: false })
+    expect(wrapper.find('button')).to.have.attr('disabled')
   })
 
   describe('ladda instance', () => {

--- a/test/LaddaButton-test.jsx
+++ b/test/LaddaButton-test.jsx
@@ -88,6 +88,11 @@ describe('LaddaButton', () => {
   it('should disable the button if the `props.disabled` is set', () => {
     const wrapper = mount(<LaddaButton disabled />)
     expect(wrapper.find('button').prop('disabled')).to.eq(true)
+    expect(wrapper.find('button')).to.have.attr('disabled')
+    wrapper.setProps({ loading: true })
+    wrapper.setProps({ loading: false })
+    expect(wrapper.find('button').prop('disabled')).to.eq(true)
+    expect(wrapper.find('button')).to.have.attr('disabled')
   })
 
   it('should disable the button if `props.loading` is truthy', () => {


### PR DESCRIPTION
[Calling `this.laddaInstance.stop()` removes the attribute `disabled`, even if `props.disabled === true`.](https://github.com/hakimel/Ladda/blob/master/js/ladda.js#L117)

In images:

![screen shot 2017-01-28 at 17 27 50](https://cloud.githubusercontent.com/assets/591804/22398226/84e0370c-e584-11e6-8e1b-7c93eda9242e.png)

![screen shot 2017-01-28 at 17 28 16](https://cloud.githubusercontent.com/assets/591804/22398227/86a95f0a-e584-11e6-8b7a-05726dcd8d46.png)

This PR fixes the problem.