### PR TITLE
Update component to use external prop-types instead of React

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,5 @@ jspm_packages
 
 dist
 
-#webstorm data
+# Webstorm
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ jspm_packages
 .node_repl_history
 
 dist
+
+#webstorm data
+.idea

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "homepage": "https://github.com/jsdir/react-ladda#readme",
   "dependencies": {
-    "ladda": "^1.0.0"
+    "ladda": "^1.0.0",
+    "prop-types": "^15.5.8"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",

--- a/src/LaddaButton.jsx
+++ b/src/LaddaButton.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from "prop-types";
 import Ladda from 'ladda'
 
 import { SIZES, STYLES } from './constants'

--- a/src/LaddaButton.jsx
+++ b/src/LaddaButton.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PropTypes from "prop-types";
+import PropTypes from 'prop-types'
 import Ladda from 'ladda'
 
 import { SIZES, STYLES } from './constants'


### PR DESCRIPTION
Hi,
propTypes from React are moved to own package, and will be removed in near release,
This small RP are fix this deprecation.

Thanks!