### PR TITLE
Bump Ladda to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/jsdir/react-ladda#readme",
   "dependencies": {
-    "ladda": "^1.0.0",
+    "ladda": "^2.0.0",
     "prop-types": "^15.5.8"
   },
   "devDependencies": {

--- a/src/LaddaButton.jsx
+++ b/src/LaddaButton.jsx
@@ -75,11 +75,6 @@ class LaddaButton extends Component {
     if (props.loading !== this.props.loading) {
       if (props.loading) {
         this.laddaInstance.start()
-      } else if (props.disabled) {
-        // .stop removes the attribute "disabled"
-        // .disable calls .stop then adds the attribute "disabled"
-        // see https://github.com/hakimel/Ladda/blob/master/js/ladda.js
-        this.laddaInstance.disable()
       } else {
         this.laddaInstance.stop()
       }

--- a/src/LaddaButton.jsx
+++ b/src/LaddaButton.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import Ladda from 'ladda'
+import { create } from 'ladda'
 
 import { SIZES, STYLES } from './constants'
 
@@ -48,7 +48,7 @@ class LaddaButton extends Component {
   };
 
   componentDidMount() {
-    this.laddaInstance = Ladda.create(this.node)
+    this.laddaInstance = create(this.node)
 
     if (this.props.loading) {
       this.laddaInstance.start()


### PR DESCRIPTION
This PR makes react-ladda works in create-react-app v2.

For those interested in a quick and temporary solution:

```
yarn remove react-ladda
yarn add https://github.com/ggregoire/react-ladda#93e39a1ac2c4e915e692e1faa6920a18d61e720f
```

And update your package.json to build react-ladda:

```
"start": "npm install --prefix ./node_modules/react-ladda && ./node_modules/react-ladda/node_modules/.bin/babel ./node_modules/react-ladda/src --out-dir ./node_modules/react-ladda/dist && react-scripts start",
"build": "npm install --prefix ./node_modules/react-ladda && ./node_modules/react-ladda/node_modules/.bin/babel ./node_modules/react-ladda/src --out-dir ./node_modules/react-ladda/dist && react-scripts build",
```

---

It seems to miss a build task to make the tests pass:

```
/home/travis/build/jsdir/react-ladda/node_modules/ladda/js/ladda.js:9
 import {Spinner} from 'spin.js';
 ^^^^^^
SyntaxError: Unexpected token import
```

I'm not super interested in fixing the build for the CI (and don't have much time to do so). Please update the PR if you have a solution to fix it. Or maybe we just have to update the node version in Travis?